### PR TITLE
change workflow trigger back to what it is in all other projects

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,7 +1,9 @@
 name: "Build and push to GHCR"
 on:
-  push:
-    tags: [ v* ]
+  workflow_run:
+    workflows: [ "Release new version" ]
+    types:
+      - completed
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Commit version adjustments
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Update project version to ${{ env.version_STRING }} (${{ env.VERSION_ADJUSTMENT }}) [skip ci]
+          commit_message: Update project version to ${{ env.VERSION_STRING }} (${{ env.VERSION_ADJUSTMENT }}) [skip ci]
           commit_user_name: Fintraffic GitHub Actions Bot
           commit_user_email: fintraffic-github-actions-bot@solita.fi
           tagging_message: ${{ env.VERSION_STRING }}


### PR DESCRIPTION
version generation would create a tag which would create an infinite loop, we don't like that