### PR TITLE
fix mkdirp reference and types for updated package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@types/libxmljs": "^0.18.8",
         "@types/lodash": "^4.14.165",
         "@types/luxon": "^1.25.0",
-        "@types/mkdirp": "^1.0.1",
         "@types/ngeohash": "0.6.8",
         "@types/pg": "^7.14.6",
         "@types/rimraf": "^3.0.0",
@@ -232,14 +231,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
-    },
-    "node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mocha": {
       "version": "8.2.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@types/libxmljs": "^0.18.8",
     "@types/lodash": "^4.14.165",
     "@types/luxon": "^1.25.0",
-    "@types/mkdirp": "^1.0.1",
     "@types/ngeohash": "0.6.8",
     "@types/pg": "^7.14.6",
     "@types/rimraf": "^3.0.0",

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import archiver from 'archiver';
 import {existsSync, readdir} from "fs";
 import {resolve} from 'path';
-import mkdirp from "mkdirp";
+import {mkdirp} from 'mkdirp';
 import * as fs from 'fs';
 import rimraf from 'rimraf';
 import zlib from 'zlib';


### PR DESCRIPTION
dependabot's 1.0.4 -> 3.0.1 update caused container build not to work anymore