### PR TITLE
fix: upgrade tsconfig target/lib from es5/es2021 to es2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,25 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/iron  # 20.x
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
   sonarcloud:
     name: Run SonarCloud Analysis
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "module": "commonjs",
-    "lib": ["es2021"],
+    "lib": ["es2022"],
     "allowJs": true,
     "outDir": "build",
     "rootDir": "src",


### PR DESCRIPTION
TypeScript 6.x deprecated the es5 target, causing the Docker build to fail with TS5107.


EDIT: Also noticed the build workflow is not actually building switch is why for example broken dependabot updates did not get cauth. Added build step to the workflow