### PR TITLE
Fix serialize-javascript RCE (Dependabot alert #55)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3264,15 +3264,6 @@
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
       "dev": true
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3405,12 +3396,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "xpath": "0.0.34"
   },
   "overrides": {
-    "logform": "2.4.2"
+    "logform": "2.4.2",
+    "serialize-javascript": ">=7.0.3"
   }
 }


### PR DESCRIPTION
## Security fix

Bumps `serialize-javascript` from 6.0.2 to 7.0.7 via npm `overrides` to resolve Dependabot alert #55.

### Vulnerability
**RCE via RegExp.flags and Date.prototype.toISOString()** — `serialize-javascript@6.0.2` is a transitive dependency of `mocha` (dev scope only). The patched version is 7.0.3; stable mocha@11.x declares `^6.0.2` and will not update to v7, so an npm override is the correct fix pattern.

### Why an override is safe here

An npm override forces a specific resolved version of a transitive dependency regardless of what the parent package declares. Three reasons this is safe:

1. **The public API is unchanged.** Both v6 and v7 export the same function: `module.exports = function serialize(obj, options)`. Mocha's call sites are unaffected.

2. **The only breaking change is the Node.js engine requirement.** v7 replaces the `randombytes` polyfill with native `crypto.getRandomValues`, which requires Node ≥ 20. This repo's CI already runs on `lts/iron` (Node 20.x), so this is satisfied.

3. **mocha itself has validated this upgrade path.** mocha@12-rc (the next major) declares `serialize-javascript: ^7.0.2`, meaning the mocha team ran their own test suite against v7 and shipped it. The only reason mocha@11.x still pins `^6.0.2` is that v11 predates the v7 release of serialize-javascript.

This is a dev-only dependency (test runner). No production code is affected.

### Change
Added to `package.json` overrides (same pattern as existing `logform` override):
```json
"serialize-javascript": ">=7.0.3"
```

Resolved version in lockfile: **7.0.7**

Closes Dependabot alert #55.