### PR TITLE
Fix brace-expansion 1.x/2.x and js-yaml CVE (HIGH)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,9 +2141,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2813,9 +2813,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
     "minimatch@>=10": {
       "brace-expansion": "^5.0.7"
     },
-    "js-yaml": "^4.3.0"
+    "js-yaml": "^4.3.0",
+    "minimatch@<5": {
+      "brace-expansion": "^1.1.16"
+    },
+    "minimatch@>=5 <10": {
+      "brace-expansion": "^2.1.2"
+    }
   }
 }


### PR DESCRIPTION
Fix remaining HIGH transitive dependency vulnerabilities via npm overrides.

## brace-expansion 1.x CVE (< 1.1.16)
Override: `"minimatch@<5": {"brace-expansion": "^1.1.16"}`

## brace-expansion 2.x CVE (< 2.1.2)
Override: `"minimatch@>=5 <10": {"brace-expansion": "^2.1.2"}`

All overrides are scoped to the relevant minimatch version range to avoid affecting other major versions.